### PR TITLE
Integer left shift overflow fix; inherit from Exception

### DIFF
--- a/src/rlib/exit.py
+++ b/src/rlib/exit.py
@@ -1,4 +1,4 @@
-class Exit(BaseException):
+class Exit(Exception):
     """
     Use an exit exception to end program execution.
     We don't use sys.exit because it is a little problematic with RPython.

--- a/src/som/compiler/parser.py
+++ b/src/som/compiler/parser.py
@@ -7,7 +7,7 @@ from .method_generation_context import MethodGenerationContext
 from .symbol                    import Symbol, symbol_as_str
 
 
-class ParseError(BaseException):
+class ParseError(Exception):
     def __init__(self, message, expected_sym, parser):
         self._message           = message
         self._line              = parser._lexer.get_current_line_number()

--- a/src/som/interpreter/control_flow.py
+++ b/src/som/interpreter/control_flow.py
@@ -1,4 +1,4 @@
-class ReturnException(BaseException):
+class ReturnException(Exception):
     
     _immutable_fields_ = ["_result", "_target"]
     

--- a/src/som/primitives/integer_primitives.py
+++ b/src/som/primitives/integer_primitives.py
@@ -105,6 +105,8 @@ def _leftShift(ivkbl, frame, interpreter):
     l = left.get_embedded_integer()
     r = right.get_embedded_integer()
     try:
+        if not (l == 0 or 0 <= r <= 63):
+            raise OverflowError
         result = ovfcheck(l << r)
         frame.push(universe.new_integer(result))
     except OverflowError:

--- a/src/som/primitives/integer_primitives.py
+++ b/src/som/primitives/integer_primitives.py
@@ -1,4 +1,4 @@
-from rpython.rlib.rarithmetic import ovfcheck
+from rpython.rlib.rarithmetic import ovfcheck, LONG_BIT
 from rpython.rlib.rbigint import rbigint
 from som.primitives.primitives import Primitives
 from som.vmobjects.integer import Integer
@@ -105,7 +105,7 @@ def _leftShift(ivkbl, frame, interpreter):
     l = left.get_embedded_integer()
     r = right.get_embedded_integer()
     try:
-        if not (l == 0 or 0 <= r <= 63):
+        if not (l == 0 or 0 <= r < LONG_BIT):
             raise OverflowError
         result = ovfcheck(l << r)
         frame.push(universe.new_integer(result))

--- a/src/targetsomstandalone.py
+++ b/src/targetsomstandalone.py
@@ -17,7 +17,7 @@ def entry_point(argv):
     except Exception, e:
         os.write(2, "ERROR: %s thrown during execution.\n" % e)
         return 1
-    return 0
+    return 1
 
 
 # _____ Define and setup target ___

--- a/src/targetsomstandalone.py
+++ b/src/targetsomstandalone.py
@@ -4,7 +4,9 @@
 import sys
 
 from som.vm.universe import main, Exit
+from som.interpreter.control_flow import ReturnException
 
+import os
 
 # __________  Entry points  __________
 
@@ -13,6 +15,14 @@ def entry_point(argv):
         main(argv)
     except Exit, e:
         return e.code
+    except ReturnException, e:
+        os.write(2, "ERROR: Caught ReturnException in entry_point. result: %s, target: %s\n" %
+                 (e._result, e._target))
+        return 1
+    except Exception, e:
+        os.write(2, "ERROR: Exception thrown during execution: " + str(e) + "\n")
+        return 1
+    os.write(2, "ERROR: Program exited without raising the Exit exception.\n")
     return 1
 
 

--- a/src/targetsomstandalone.py
+++ b/src/targetsomstandalone.py
@@ -4,7 +4,6 @@
 import sys
 
 from som.vm.universe import main, Exit
-from som.interpreter.control_flow import ReturnException
 
 import os
 

--- a/src/targetsomstandalone.py
+++ b/src/targetsomstandalone.py
@@ -15,15 +15,10 @@ def entry_point(argv):
         main(argv)
     except Exit, e:
         return e.code
-    except ReturnException, e:
-        os.write(2, "ERROR: Caught ReturnException in entry_point. result: %s, target: %s\n" %
-                 (e._result, e._target))
-        return 1
     except Exception, e:
-        os.write(2, "ERROR: Exception thrown during execution: " + str(e) + "\n")
+        os.write(2, "ERROR: %s thrown during execution.\n" % e)
         return 1
-    os.write(2, "ERROR: Program exited without raising the Exit exception.\n")
-    return 1
+    return 0
 
 
 # _____ Define and setup target ___


### PR DESCRIPTION
The reason that 1 << 70 in the IntegerTest is failing is because ovfcheck in RPython does not raise an exception when shifting by 70. Thus it is fixed by explicitly demanding that the shift amount must be within the range(0, LONG_BIT).

Another problem is that the exceptions are inheriting from BaseException. They should inherit from Exception instead.