### PR TITLE
Fix array strategy selection logic causing wrong storage backing to be selected

### DIFF
--- a/src/som/compiler/ast/parser.py
+++ b/src/som/compiler/ast/parser.py
@@ -240,21 +240,7 @@ class Parser(ParserBase):
         elif self._sym == Symbol.STString:
             return self._literal_string()
         else:
-            is_negative = self._is_negative_number()
-            if self._sym == Symbol.Integer:
-                return self._literal_integer(is_negative)
-            elif self._sym != Symbol.Double:
-                raise ParseError("Unexpected symbol. Expected %(expected)s, "
-                                 "but found %(found)s", self._sym, self)
-            else:
-                return self._literal_double(is_negative)
-
-    def _is_negative_number(self):
-        is_negative = False
-        if self._sym == Symbol.Minus:
-            self._expect(Symbol.Minus)
-            is_negative = True
-        return is_negative
+            return self._literal_number()
 
     def _literal_number(self):
         if self._sym == Symbol.Minus:

--- a/src/som/vmobjects/array_strategy.py
+++ b/src/som/vmobjects/array_strategy.py
@@ -801,16 +801,19 @@ class Array(AbstractObject):
             if v is None or v is nilObject:
                 continue
             if isinstance(v, int) or isinstance(v, Integer):
-                only_double = False
                 is_empty    = False
+                only_double = False
+                only_bool   = False
                 continue
             if isinstance(v, float) or isinstance(v, Double):
-                only_long = False
                 is_empty  = False
+                only_long = False
+                only_bool = False
                 continue
             if isinstance(v, bool) or v is trueObject or v is falseObject:
-                only_bool = False
-                is_empty  = False
+                is_empty    = False
+                only_long   = False
+                only_double = False
                 continue
             only_long   = False
             only_double = False

--- a/src/som/vmobjects/biginteger.py
+++ b/src/som/vmobjects/biginteger.py
@@ -15,6 +15,9 @@ class BigInteger(AbstractObject):
     def get_embedded_biginteger(self):
         return self._embedded_biginteger
 
+    def __str__(self):
+        return str(self._embedded_biginteger)
+
     def get_class(self, universe):
         return universe.integerClass
 

--- a/src/som/vmobjects/double.py
+++ b/src/som/vmobjects/double.py
@@ -17,6 +17,9 @@ class Double(AbstractObject):
     def get_embedded_double(self):
         return self._embedded_double
 
+    def __str__(self):
+        return str(self._embedded_double)
+
     def get_class(self, universe):
         return universe.doubleClass
 

--- a/src/som/vmobjects/method_ast.py
+++ b/src/som/vmobjects/method_ast.py
@@ -52,8 +52,11 @@ class AstMethod(AbstractObject):
         return self._invokable.invoke(receiver, args)
 
     def __str__(self):
-        return ("Method(" + self.get_holder().get_name().get_embedded_string() + ">>" +
-                str(self.get_signature()) + ")")
+        if self._holder:
+            holder = self._holder.get_name().get_embedded_string()
+        else:
+            holder = 'nil'
+        return ("Method(" + holder + ">>" + str(self.get_signature()) + ")")
 
     def get_class(self, universe):
         return universe.methodClass

--- a/src/som/vmobjects/primitive.py
+++ b/src/som/vmobjects/primitive.py
@@ -42,8 +42,11 @@ class _AbstractPrimitive(AbstractObject):
         return universe.primitiveClass
 
     def __str__(self):
-        return ("Primitive(" + self.get_holder().get_name().get_embedded_string() + ">>"
-                + str(self.get_signature()) + ")")
+        if self._holder:
+            holder = self.get_holder().get_name().get_embedded_string()
+        else:
+            holder = "nil"
+        return ("Primitive(" + holder + ">>" + str(self.get_signature()) + ")")
 
 
 class _AstPrimitive(_AbstractPrimitive):


### PR DESCRIPTION
This updates the core-lib and fix how arrays are created from values.

Previously, the logic to determine which values are in the array was wrong.

The PR also improves the __str__ logic on some elements, and updates the core-lib